### PR TITLE
sepolicy: Use the real path for sysfs nodes instead of symlinks

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,2 +1,2 @@
-/sys/devices/virtual/input/clearpad/glove -- u:object_r:sysfs_touch:s0
-/sys/devices/virtual/input/clearpad/wakeup_gesture -- u:object_r:sysfs_touch:s0
+/sys/devices/virtual/input/input1/glove -- u:object_r:sysfs_touch:s0
+/sys/devices/virtual/input/input1/wakeup_gesture -- u:object_r:sysfs_touch:s0


### PR DESCRIPTION
Change-Id: I12409e49762954c666055098a4193efdb5d6bd1d